### PR TITLE
LON-801

### DIFF
--- a/LongoMatch.Core/Store/Templates/Dashboard.cs
+++ b/LongoMatch.Core/Store/Templates/Dashboard.cs
@@ -224,10 +224,12 @@ namespace LongoMatch.Core.Store.Templates
 		/// </summary>
 		public Dashboard Copy (string newName)
 		{
+			Load ();
 			Dashboard newDashboard = this.Clone ();
 			newDashboard.ID = Guid.NewGuid ();
+			newDashboard.DocumentID = null;
 			newDashboard.Name = newName;
-			foreach (AnalysisEventButton evtButton in List.OfType<AnalysisEventButton> ()) {
+			foreach (AnalysisEventButton evtButton in newDashboard.List.OfType<AnalysisEventButton> ()) {
 				evtButton.EventType.ID = Guid.NewGuid ();
 			}
 			return newDashboard;

--- a/LongoMatch.Core/Store/Templates/Team.cs
+++ b/LongoMatch.Core/Store/Templates/Team.cs
@@ -234,10 +234,12 @@ namespace LongoMatch.Core.Store.Templates
 		/// </summary>
 		public Team Copy (string newName)
 		{
+			Load ();
 			Team newTeam = this.Clone ();
 			newTeam.ID = Guid.NewGuid ();
+			newTeam.DocumentID = null;
 			newTeam.Name = newName;
-			foreach (Player player in List) {
+			foreach (Player player in newTeam.List) {
 				player.ID = Guid.NewGuid ();
 			}
 			return newTeam;

--- a/LongoMatch.GUI/Gui/Panel/TeamsTemplatesPanel.cs
+++ b/LongoMatch.GUI/Gui/Panel/TeamsTemplatesPanel.cs
@@ -237,6 +237,9 @@ namespace LongoMatch.Gui.Panel
 			teamseditortreeview.Model.SetValue (selectedIter, COL_PIXBUF, shield);
 			teamseditortreeview.Model.SetValue (selectedIter, COL_TEAM, loadedTeam);
 			teamtemplateeditor1.Edited = false;
+			//Replace the old team with the new one with the new attributes
+			teams.RemoveAll (t => t.ID == loadedTeam.ID);
+			teams.Add (loadedTeam);
 		}
 
 		void SaveStatic ()
@@ -396,7 +399,7 @@ namespace LongoMatch.Gui.Panel
 		void HandleNewTeamClicked (object sender, EventArgs e)
 		{
 			bool create = false;
-			bool force = false;
+			Team auxdelete = null;
 			
 			EntryDialog dialog = new EntryDialog (Toplevel as Gtk.Window);
 			dialog.ShowCount = true;
@@ -411,17 +414,11 @@ namespace LongoMatch.Gui.Panel
 				} else if (dialog.Text == "default") {
 					MessagesHelpers.ErrorMessage (dialog, Catalog.GetString ("The template can't be named 'default'."));
 					continue;
-				} else if (dialog.Text == dialog.SelectedTemplate) {
-					/* The new template has the same name as the orignal one,
-					 * just reload it as if we where copying it */
-					Load (dialog.Text);
-					break;
 				} else if (provider.Exists (dialog.Text)) {
-					var msg = Catalog.GetString ("The template already exists. " +
-					          "Do you want to overwrite it?");
+					var msg = Catalog.GetString ("The template already exists. Do you want to overwrite it?");
 					if (MessagesHelpers.QuestionMessage (this, msg)) {
 						create = true;
-						force = true;
+						auxdelete = teams.FirstOrDefault (t => t.Name == dialog.Text);
 						break;
 					}
 				} else {
@@ -442,6 +439,9 @@ namespace LongoMatch.Gui.Panel
 						dialog.Destroy ();
 						return;
 					}
+				}
+				if (auxdelete != null) {
+					provider.Delete (auxdelete);
 				}
 				Load (dialog.Text);
 			}

--- a/Tests/Services/TestTemplatesService.cs
+++ b/Tests/Services/TestTemplatesService.cs
@@ -15,7 +15,6 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 //
-using System;
 using System.Collections.Specialized;
 using System.IO;
 using LongoMatch.Core.Common;
@@ -151,6 +150,37 @@ namespace Tests.Services
 			Assert.IsNotNull (provider.Exists ("NEW"));
 			Assert.DoesNotThrow (() => provider.Copy (Dashboard.DefaultTemplate (5), "NEW"));
 			Assert.IsTrue (eventEmitted);
+		}
+
+		[Test ()]
+		public void TestCopyOverwrite ()
+		{
+			TemplatesService ts = new TemplatesService (storage);
+			ts.Start ();
+			ITeamTemplatesProvider teamtemplateprovider = ts.TeamTemplateProvider;
+			Team teamB = Team.DefaultTemplate (5);
+			teamB.Name = "B";
+			teamB.TeamName = "Template B";
+			teamB.FormationStr = "1-4";
+			teamB.List [0].Name = "Paco";
+			teamtemplateprovider.Save (teamB);
+			Team teamA = new Team ();
+			teamA.Name = "A";
+			teamA.TeamName = "Template A";
+			teamA.FormationStr = "1-4-3-3";
+			teamtemplateprovider.Save (teamA);
+
+			Team auxdelete = teamA;
+			teamtemplateprovider.Copy (teamB, "A");
+			teamtemplateprovider.Delete (auxdelete);
+			teamA = teamtemplateprovider.Templates [0];
+
+			Assert.AreEqual (4, teamtemplateprovider.Templates.Count);
+			Assert.AreEqual ("A", teamA.Name);
+			Assert.AreEqual ("Template B", teamA.TeamName);
+			Assert.AreEqual (teamB.List.Count, teamA.List.Count);
+			Assert.AreEqual ("1-4", teamA.FormationStr);
+			Assert.AreEqual ("Paco", teamA.List [0].Name);
 		}
 
 		[Test ()]


### PR DESCRIPTION
Fix: Copying teams on teamsmanager with overwriting errors
Also add a unit test and do the same procedure with dashboard.cs
as with team.cs to avoid the same problem.